### PR TITLE
Stretch alignment XamlDisplay

### DIFF
--- a/ShowMeTheXaml.Avalonia/XamlDisplay.xaml
+++ b/ShowMeTheXaml.Avalonia/XamlDisplay.xaml
@@ -14,8 +14,8 @@
   </Style>
   
   <Style Selector="showMeTheXaml|XamlDisplay">
-    <Setter Property="HorizontalAlignment" Value="Center" />
-    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
     <Setter Property="Template">
       <ControlTemplate>
         <Grid ColumnDefinitions="*, Auto">


### PR DESCRIPTION
There was a mistake on VerticalAlignment and HorizontalAlignment, and the whole XamlDisplay will centerize instead of fill the space for it. This small PR will correct the behaviour.